### PR TITLE
added shouldshowUpdateReminder Variable to BITUpdateManager

### DIFF
--- a/Classes/BITUpdateManager.h
+++ b/Classes/BITUpdateManager.h
@@ -155,6 +155,15 @@ typedef NS_ENUM (NSUInteger, BITUpdateSetting) {
  */
 @property (nonatomic, assign) BOOL alwaysShowUpdateReminder;
 
+/**
+ Flag that determines if update alerts should be shown at all
+ If enabled, functions as with alwaysShowUpdateReminder
+ if disabled, the updates popup is never shown
+ 
+ Default : YES
+ 
+ */
+@property (nonatomic, assign) BOOL shouldShowUpdateReminder;
 
 /**
  Flag that determines if the update alert should show a direct install option

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -467,6 +467,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
     // set defaults
     self.showDirectInstallOption = NO;
     self.alwaysShowUpdateReminder = YES;
+    self.shouldShowUpdateReminder = YES;
     self.checkForUpdateOnLaunch = YES;
     self.updateSetting = BITUpdateCheckStartup;
     
@@ -834,7 +835,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
     if ([self expiryDateReached]) return;
     if (![self installationIdentified]) return;
     
-    if (self.isUpdateAvailable && [self hasNewerMandatoryVersion]) {
+    if (self.isUpdateAvailable && [self hasNewerMandatoryVersion] && self.shouldShowUpdateReminder) {
       [self showCheckForUpdateAlert];
     }
     
@@ -1151,7 +1152,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
         }
         
         if (self.isUpdateAvailable && (self.alwaysShowUpdateReminder || newVersionDiffersFromCachedVersion || [self hasNewerMandatoryVersion])) {
-          if (_updateAvailable && !_currentHockeyViewController) {
+          if (_updateAvailable && !_currentHockeyViewController && self.shouldShowUpdateReminder) {
             [self showCheckForUpdateAlert];
           }
         }


### PR DESCRIPTION
if the shouldshowUpdateReminder is set to true, the app update popup is showed as
normal, if it is set to false the update popup is never showed
the variable is by default true